### PR TITLE
Add SummaryContainer component

### DIFF
--- a/src/Components/SummaryContainer.razor
+++ b/src/Components/SummaryContainer.razor
@@ -1,0 +1,17 @@
+<div class="article-summary mb-4">
+    <div class="summary-header">
+        <h6 class="summary-title">
+            <i class="fas fa-list-ul me-2"></i>
+            Summary
+        </h6>
+    </div>
+    <div class="summary-content">
+        <div class="row">
+            @ChildContent
+        </div>
+    </div>
+</div>
+@code {
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+}

--- a/src/Components/SummaryContainer.razor.css
+++ b/src/Components/SummaryContainer.razor.css
@@ -1,0 +1,88 @@
+/* Article Summary Box Styles */
+.article-summary {
+    background: linear-gradient(135deg, rgba(var(--bs-primary-rgb), 0.05), rgba(var(--bs-info-rgb), 0.03));
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+    overflow: hidden;
+    position: relative;
+}
+
+.article-summary::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, var(--bs-primary), var(--bs-info));
+}
+
+.summary-header {
+    padding: 1rem 1.5rem 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.summary-title {
+    color: var(--bs-light);
+    font-weight: 600;
+    margin-bottom: 0;
+    font-size: 1rem;
+}
+
+.summary-content {
+    padding: 1rem 1.5rem 1.5rem;
+}
+
+.summary-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.summary-list li {
+    padding: 0.375rem 0;
+    color: var(--bs-light);
+    position: relative;
+    padding-left: 1.5rem;
+}
+
+.summary-list li::before {
+    content: '✓';
+    position: absolute;
+    left: 0;
+    color: var(--bs-success);
+    font-weight: bold;
+}
+
+.summary-meta {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.summary-stat {
+    font-size: 0.875rem;
+    color: var(--bs-secondary);
+    display: flex;
+    align-items: center;
+}
+
+.summary-stat strong {
+    color: var(--bs-light);
+}
+
+@media (max-width: 768px) {
+    .summary-content {
+        padding: 1rem;
+    }
+
+    .summary-header {
+        padding: 1rem 1rem 0;
+    }
+
+    .summary-meta .d-flex {
+        flex-direction: column;
+        align-items: flex-start !important;
+        gap: 0.5rem !important;
+    }
+}

--- a/src/Pages/2 Using Blake/AuthoringContent.md
+++ b/src/Pages/2 Using Blake/AuthoringContent.md
@@ -10,8 +10,7 @@ category: "Using Blake"
 quickAccess: 2
 ---
 
-:::info
-**Summary**
+:::summary
 Blake turns Markdown files into Blazor pages using Razor templates. Just write content - Blake handles the rest with zero configuration required.
 :::
 

--- a/src/_Imports.razor
+++ b/src/_Imports.razor
@@ -8,6 +8,7 @@
 @using Microsoft.AspNetCore.Components.WebAssembly.Http
 @using Microsoft.JSInterop
 @using BlakeSampleDocs
+@using BlakeSampleDocs.Components
 @using BlakeSampleDocs.Layout
 @using BlakeSampleDocs.Services
 @using Blake.Types


### PR DESCRIPTION
This pull request introduces a new reusable `SummaryContainer` component for displaying article summaries and applies related styling improvements. It also updates documentation to use the new summary format and ensures the component namespace is available throughout the project.

**Component Addition and Styling**

* Added the new `SummaryContainer` component in `src/Components/SummaryContainer.razor`, which provides a styled container for summary content using a Razor parameter for child fragments.
* Introduced `src/Components/SummaryContainer.razor.css` with custom styles for the summary box, including gradient backgrounds, borders, and responsive design tweaks.

**Documentation and Imports**

* Updated the summary section in `src/Pages/2 Using Blake/AuthoringContent.md` to use the new `:::summary` format instead of `:::info`, aligning documentation with the new component.
* Added `BlakeSampleDocs.Components` to project-wide Razor imports in `src/_Imports.razor` to make the new component easily accessible.