### PR TITLE
Refactor Azure deployment workflow and add build and test workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,37 @@
+name: Build and Test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    name: Build and Test Job
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Install Blake CLI
+        run: dotnet tool install -g Blake.CLI
+
+      - name: Bake static content
+        run: blake bake
+        working-directory: src
+
+      - name: Build the site
+        run: dotnet build src/BlakeSampleDocs.csproj --configuration Release
+
+      - name: Test build output
+        run: |
+          if [ ! -d "src/.generated" ]; then
+            echo "Error: Blake generated content not found"
+            exit 1
+          fi
+          echo "✅ Build completed successfully"

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -1,18 +1,15 @@
 name: Deploy to Azure Static Web Apps
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [closed]
     branches:
       - main
   workflow_dispatch:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
@@ -48,15 +45,3 @@ jobs:
           skip_api_build: true
           skip_app_build: true # Skip Oryx app build because Oryx incorrectly detects the project framework, leading to a failed or incorrect build. The app is built manually in the previous step.
           ###### End of Repository/Build Configurations ######
-
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request Job
-    steps:
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
-          action: "close"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve build, test, and deployment automation for the project. The main changes include adding a dedicated workflow for building and testing the project on pull requests, refining the deployment workflow to Azure Static Web Apps to trigger only on merged pull requests, and removing unnecessary steps related to closing pull requests.

**Continuous Integration Improvements:**

* Added a new workflow `.github/workflows/build-test.yml` to automatically build and test the project on pull requests targeting the `main` branch, including setup for .NET 9, Blake CLI installation, static content generation, and build verification.

**Deployment Workflow Refinements:**

* Updated `.github/workflows/deploy-azure.yml` to trigger deployments only when a pull request is closed and merged into `main`, ensuring deployments occur only for merged changes.
* Removed the `close_pull_request_job` from `.github/workflows/deploy-azure.yml`, eliminating redundant steps for closing pull requests in the deployment workflow.