### PR TITLE
Added step to copy static web app routes to output

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -34,6 +34,9 @@ jobs:
         id: build
         run: dotnet publish src/BlakeSampleDocs.csproj --configuration Release -o site_output
 
+      - name: Copy Route Config
+        run: cp -R staticwebapp.config.json site_output/wwwroot/
+
       - name: Build And Deploy
         id: deploy
         uses: Azure/static-web-apps-deploy@v1


### PR DESCRIPTION
This pull request introduces an additional deployment step to ensure the route configuration is included in the published output. Specifically, it adds a command to copy the `staticwebapp.config.json` file into the `site_output/wwwroot/` directory before deploying to Azure.

Deployment process improvement:

* Added a step to copy `staticwebapp.config.json` into `site_output/wwwroot/` to ensure route configuration is present during deployment.