### PR TITLE
Add image and markdown notes to docs

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -4,15 +4,11 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:

--- a/src/Pages/2 Using Blake/AuthoringContent.md
+++ b/src/Pages/2 Using Blake/AuthoringContent.md
@@ -14,11 +14,10 @@ quickAccess: 2
 Blake turns Markdown files into Blazor pages using Razor templates. Just write content - Blake handles the rest with zero configuration required.
 :::
 
-## Authoring Content in Blake
-
 Blake provides a flexible framework for creating and managing content. This guide will walk you through the essential steps to author content effectively.
 
 **The Blake workflow is simple:**
+
 1. Create or organize Markdown files in folders
 2. Add frontmatter to control metadata (optional but recommended)  
 3. Run `blake bake` to generate Blazor components
@@ -26,7 +25,7 @@ Blake provides a flexible framework for creating and managing content. This guid
 
 Let's explore each step in detail.
 
-### Page Templates
+## Page Templates
 
 Blake uses Razor components as templates for pages. Page templates are defined as either `template.razor` files, or `cascading-template.razor` files, which allow for cascading parameters to be passed down to child components.
 
@@ -34,7 +33,53 @@ Any directory containing Markdown file (`.md`) files will be treated as a conten
 
 You can read more about how these work in [Page Templates](/pages/2 using blake/page-templates).
 
-### Content Structure
+## General Markdown Notes
+
+Content in Blake is written in Markdown. If you're interested in Blake it's likely you know what Markdown is and how to use it, but if not, check out the [Markdown guide](https://www.markdownguide.org/). It's trivial to learn and use (seriously, I've seen everyone from high school work experience placements to retirees pick it up in minutes).
+
+While there are different "flavours" of Markdown, pretty much all general Markdown syntax will work with Blake. It uses [Markdig](https://github.com/xoofx/markdig) to transform Markdown into HTML, with some additional tweaks around the edges, like transposing unrecognised containers to Razor components (see [components](/2%20using%20blake/components) page for more info).
+
+When using a static site generator like Blake, the general idea is to define styles in your templates, and let the Markdown parser take care of the rest. If however you do want to explicitly control some aspect of your content directly in Makrdown, Markdig allows you to [supply attributes](https://github.com/xoofx/markdig/blob/master/src/Markdig.Tests/Specs/GenericAttributesSpecs.md) alongside your content byt enclosing them in curly braces. For example:
+
+```markdown
+You can add curly braces after anything{#paragraph-6 .my-paragraph}
+```
+
+The convention with Markdig is as follows:
+
+* A hash (`#`) specifies the ID
+* A period (`.`) is used to specify a CSS class
+* Any other attribute is supplied as a key-value pair with the equals sign (`name="value"`)
+
+### A note in images
+
+You can use these attributes to control image sizing, if you want to, e.g.:
+
+```markdown
+![An image](/path/to/image.png){width="400" height="200"}
+```
+
+This would get parsed as:
+
+```html
+<img src="path/to/image.png" alt="An image" Width="400" Height="200">
+```
+
+Blake also has some special shorthand for image sizing though for extra convenience. After the file path, you can use the equals sign to specify dimensions (in `px`) with positional properties, in the order `=[width]x[height]`. You can specify both, or just one with the `x` used to indicate which property you are specifying.
+
+```markdown
+![Alt text](/path/to/image.png=200x300)  # Both width and height
+![Alt text](/path/to/image.png=400x)     # Width only, height auto
+![Alt text](/path/to/image.png=x250)     # Height only, width auto
+```
+
+You can of course ignore all this and just size your images themselves (or not), and let them just render by default:
+
+```markdown
+![Alt text](/path/to/image.png)
+```
+
+## Content Structure
 
 Unlike other static site generators, Blake does not enforce a specific content structure. You can organize your content in any way that makes sense for your project. Navigation and URLs are automatically generated based on file path, therefore it is recommended to follow a logical hierarchy to make navigation easier for users.
 
@@ -42,7 +87,7 @@ Unlike other static site generators, Blake does not enforce a specific content s
 With the DocsRenderer plugin, you can also create a table of contents (ToC) for your pages. This is useful for longer documents or guides where users may want to jump to specific sections. It also allows you to specify categories in your frontmatter, which can be used to group related content together. Note that the URL/slug does not change, just organisation within the ToC.
 :::
 
-### Frontmatter
+## Front matter
 
 Blake supports frontmatter in Markdown files, allowing you to define metadata for each page. Frontmatter is not required - Blake will generate pages even if no frontmatter is present. However, it is highly recommended to use frontmatter to provide additional context and control over how your content is displayed.
 
@@ -61,14 +106,14 @@ Values parsed from frontmatter are available in the `PageModel` class. Note that
 For example, if you have a property called `Title` in your `PageModel`, you can use it in your template like this:
 
 ```razor
-<h1>&#64;Title</h1>
+<h1>@Title</h1>
 ```
 
 Any other properties are assigned to the `Metadata` dictionary, of the `PageModel` class, and can be accessed from the generated content index (see the relevant section in [Page Templates](/pages/2 using blake/page-templates)).
 
 Blake plugins can also add additional frontmatter fields, which can be used to control how content is rendered or processed. For example, the DocsRenderer plugin adds a `category` field to group related content together. You can learn more about plugins in the [Using Plugins](/pages/2 using blake/using-plugins) page.
 
-### Content Creation
+## Content Creation
 
 To create content in Blake, simply add Markdown files to your content directories. Blake will automatically generate pages for each Markdown file found in the directory when you run `blake bake`, using the specified templates.
 

--- a/src/Pages/2 Using Blake/Components.md
+++ b/src/Pages/2 Using Blake/Components.md
@@ -45,10 +45,10 @@ You can also include child content with a `RenderFragment` parameter (which is u
 ```razor
 <div class="my-component">
 	<h3>@Title</h3>
-	@@ChildContent
+	@ChildContent
 </div>
 
-@@code {
+@code {
 	[Parameter] public string Title { get; set; }
 	[Parameter] public RenderFragment ChildContent { get; set; }
 }


### PR DESCRIPTION
This pull request updates the documentation for Blake's content authoring and components, focusing on improving clarity, providing more comprehensive Markdown guidance, and correcting Razor syntax examples. The most important changes are grouped below.

Documentation improvements and expanded guidance:

* Expanded the "Authoring Content in Blake" section in `AuthoringContent.md` to include a new "General Markdown Notes" section. This explains Markdown usage, Markdig features, and image attribute conventions, including Blake-specific image sizing shorthand.
* Clarified and reorganized content structure and front matter sections, making the documentation easier to follow for new users.

Syntax corrections and consistency:

* Fixed Razor syntax examples in both `AuthoringContent.md` and `Components.md` by correcting the usage of `@Title` and `@ChildContent`, and changing `@@code` to `@code` for proper Blazor component syntax. [[1]](diffhunk://#diff-fc23823bdd36db8cb394efab658e9b12ed2e9ddf64d6df4bf74a241aa1b0532eL64-R116) [[2]](diffhunk://#diff-9d961f8fddab3428227e05c5bb5b837f58fff34003d24090d3b32fab27d4262eL48-R51)